### PR TITLE
add stp-based full simulation to get the truth table

### DIFF
--- a/src/commands/simulator.hpp
+++ b/src/commands/simulator.hpp
@@ -28,6 +28,7 @@ class simulator_command : public command {
       : command(env, "STP-based logic network simulation") {
     add_option("filename,-f", filename, "name of input file");
     add_flag("--verbose, -v", "verbose output");
+    add_flag("--full_simulation, -t", "full simulation to get the truth table");
   }
 
  protected:
@@ -48,7 +49,11 @@ class simulator_command : public command {
 
     begin = clock();
     
-    sim.simulate();
+    if(is_set("full_simulation")){
+      sim.full_simulate();
+    }else{
+      sim.simulate();
+    }
 
     end = clock();
     totalTime = (double)(end - begin) / CLOCKS_PER_SEC;

--- a/src/core/simulator/simulator.hpp
+++ b/src/core/simulator/simulator.hpp
@@ -20,6 +20,8 @@ class simulator {
  public:
   simulator(CircuitGraph& graph);
   bool simulate();  // simulate
+  bool full_simulate();  //full_simulate
+  std::vector<std::vector<int>> generateBinary(int n);
   void print_simulation_result();
 
  private:


### PR DESCRIPTION
The STP-based simulator is used for **full simulation** to obtain the truth table. At the same time, I think that setting the pattern_num to 10,000 is too big, and an option can be added later, so that users can set it according to their own needs. 
At the same time, I cited the print_simulation_result() function as not intuitive enough, and the size of sim_info is larger than the size of result, so I changed this part as well. The first submission, maybe there are still many shortcomings, thank you!